### PR TITLE
Add a collector for MQTT message bursts

### DIFF
--- a/src/mqtt.py
+++ b/src/mqtt.py
@@ -1,24 +1,27 @@
+import asyncio
+import logging
 import os
+import time
+from typing import TYPE_CHECKING, Callable, List
 
 import paho.mqtt.client as paho_mqtt
-import logging
-
-from typing import TYPE_CHECKING
 
 # Pass-through for the Paho MQTT client
 if TYPE_CHECKING:
-    from paho.mqtt.client import Client as MqttClient
+    from paho.mqtt.client import Client as MqttClient, MQTTMessage as MqttMessage
 else:
     MqttClient = paho_mqtt.Client
+    MqttMessage = paho_mqtt.MQTTMessage
+
 
 class MqttConfig:
     @staticmethod
     def from_env(env_prefix=""):
-        host = os.getenv(env_prefix+"HOST")
+        host = os.getenv(env_prefix + "HOST")
         if host is None:
             raise KeyError("Missing HOST configuration for MQTT")
 
-        prefix = os.getenv(env_prefix+"PREFIX")
+        prefix = os.getenv(env_prefix + "PREFIX")
 
         return MqttConfig(host, prefix)
 
@@ -80,6 +83,7 @@ def create_client(mqtt_config, on_disconnect_cb=None):
 
     return client
 
+
 def join_topics(prefix, *subtopics):
     """
     Joins an MQTT topic prefix with one or more subtopics, ensuring exactly one slash between each part.
@@ -96,3 +100,156 @@ def join_topics(prefix, *subtopics):
     middle = "/".join(subtopic.strip("/") for subtopic in subtopics)
     # Combine prefix and middle, preserving leading slashes
     return f"{prefix.rstrip('/')}/{middle}" if middle else prefix
+
+
+class MqttBurstCollector:
+    """
+    A class to collect MQTT messages in bursts and trigger a callback after a timeout.
+
+    The `MqttBurstCollector` listens to specified MQTT topics and collects messages.
+    It triggers a callback function with the collected messages when a timeout occurs
+    after the last received message. The timeout resets each time a new message is received.
+
+    Attributes:
+        mqtt_client (MqttClient): The MQTT client used for subscribing to topics and receiving messages.
+        topics (List[str]): A list of MQTT topics to listen to.
+        callback (Callable[[List], None]): A function to handle the collected messages when the timeout is reached.
+        timeout_s (float): The timeout duration in seconds after the last received message.
+        _last_message_timestamp (float | None): The timestamp of the last received message.
+        messages (List[MqttMessage]): A list to store the collected messages.
+        _timeout_task (asyncio.Task): An asyncio task to monitor the timeout and trigger the callback.
+    """
+
+    def __init__(self,
+                 mqtt_client: MqttClient,
+                 topics: List[str],
+                 callback: Callable[[List], None],
+                 timeout_s: float = 1.0):
+        """
+        Initialize the burst collector and start listening to the specified topics.
+
+        Args:
+            mqtt_client (MqttClient): The MQTT client to use.
+            topics (list): List of MQTT topics to listen to.
+            callback (function): Callback function to handle a list of messages.
+            timeout_s (int): Timeout in seconds after the latest message before a burst is delivered.
+        """
+        if callback is None:
+            raise ValueError("Callback function must not be None")
+
+        self.mqtt_client = mqtt_client
+        self.topics = topics
+        self.callback = callback
+        self.timeout_s = timeout_s if timeout_s > 0 else 0
+
+        self._last_message_timestamp = None
+        self._timeout_task = None
+        self._lock = asyncio.Lock()
+
+        # To store collected messages
+        self.messages = []
+
+        # Subscribe to the topics and set up message callbacks
+        for topic in self.topics:
+            self.mqtt_client.subscribe(topic)
+            self.mqtt_client.message_callback_add(topic, self._on_message)
+
+    def stop(self) -> List[MqttMessage]:
+        """
+        Stop listening to the specified topics and return the retained messages.
+
+        Returns:
+            list: The list of retained messages.
+        """
+        self._cancel_timeout_task()
+
+        for topic in self.topics:
+            self.mqtt_client.message_callback_remove(topic)
+            self.mqtt_client.unsubscribe(topic)
+
+        retained_messages = self.messages[:]
+        self._clear_messages()
+        return retained_messages
+
+    def _on_message(self, _client, _userdata, message: MqttMessage):
+        """
+        Internal method to handle incoming MQTT messages.
+
+        Args:
+            message: The received MQTT message.
+        """
+        asyncio.create_task(self._handle_message(message))
+
+    async def _handle_message(self, message: MqttMessage):
+        async with self._lock:
+            self.messages.append(message)
+            self._last_message_timestamp = time.time()
+
+            # Start a timeout task if not already running
+            self._start_timeout_task()
+
+    def _clear_messages(self):
+        """
+        Clear the list of collected messages.
+        This method is called when the timeout is reached and the callback is triggered.
+        """
+        self.messages.clear()
+        self._last_message_timestamp = None
+
+    def _start_timeout_task(self):
+        """
+        Start the timeout monitoring task if it is not already running.
+        This method is called when the collector is started.
+        """
+        if not self._timeout_task or self._timeout_task.done():
+            self._timeout_task = asyncio.create_task(self._monitor_timeout())
+
+    def _cancel_timeout_task(self):
+        """
+        Cancel the timeout monitoring task if it is running.
+        This method is called when the collector is stopped.
+        """
+        if self._timeout_task:
+            self._timeout_task.cancel()
+            self._timeout_task = None
+
+    async def _monitor_timeout(self):
+        try:
+            while True:
+                # Check periodically
+                async with self._lock:
+                    if self._last_message_timestamp is None:
+                        break
+
+                    # Calculate remaining time until timeout
+                    elapsed_time = time.time() - self._last_message_timestamp
+                    remaining_time = self.timeout_s - elapsed_time
+
+                    # Check if the timeout has been reached
+                    if remaining_time <= 0:
+                        self._trigger_callback(self.messages)
+                        self._clear_messages()
+                        break
+
+                # Wait for the remaining time
+                await asyncio.sleep(min(remaining_time, 0.1))
+        except asyncio.CancelledError:
+            # Task was cancelled
+            pass
+        except Exception as e:
+            logging.error(f"Unexpected error in _monitor_timeout: {e}")
+        finally:
+            self._timeout_task = None
+
+    def _trigger_callback(self, messages):
+        """
+        Trigger the callback with the collected messages.
+
+        Args:
+            messages: The list of collected messages.
+        """
+        try:
+            if self.callback:
+                self.callback(messages[:])  # Trigger callback with a shallow copy
+        except Exception as e:
+            logging.error(f"Error in callback: {e}")

--- a/test/test_mqtt_burst_collector.py
+++ b/test/test_mqtt_burst_collector.py
@@ -1,0 +1,88 @@
+import unittest
+from unittest.mock import MagicMock
+import asyncio
+from mqtt import MqttBurstCollector, MqttMessage
+
+
+class TestMqttBurstCollector(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.timeout_s = 0.2 # Must be at least 0.2
+
+        self.mock_mqtt_client = MagicMock()
+        self.mock_callback = MagicMock()
+
+        self.collector = MqttBurstCollector(
+            mqtt_client=self.mock_mqtt_client,
+            topics=["test/topic"],
+            callback=self.mock_callback,
+            timeout_s=self.timeout_s,
+        )
+
+    def tearDown(self):
+        self.collector.stop()
+
+    async def test_subscribes_to_topics_on_init(self):
+        # Verify topics are subscribed
+        self.mock_mqtt_client.subscribe.assert_called_once_with("test/topic")
+        self.mock_mqtt_client.message_callback_add.assert_called_once_with("test/topic", self.collector._on_message)
+
+    async def test_message_collection_and_callback(self):
+        # Simulate receiving a message
+        message = MagicMock(spec=MqttMessage)
+        await self.collector._handle_message(message)
+
+        # Verify the message is collected
+        self.assertEqual(len(self.collector.messages), 1)
+        self.assertIn(message, self.collector.messages)
+
+        # Simulate timeout
+        await asyncio.sleep(self.timeout_s + 0.1)
+        self.mock_callback.assert_called_once_with([message])
+        self.assertEqual(len(self.collector.messages), 0)
+
+    async def test_timeout_resets_on_new_message(self):
+        # Simulate receiving the first message
+        message1 = MagicMock(spec=MqttMessage)
+        await self.collector._handle_message(message1)
+
+        # Simulate receiving a second message before timeout
+        message2 = MagicMock(spec=MqttMessage)
+        await asyncio.sleep(self.timeout_s - 0.1)  # Less than the timeout
+        await self.collector._handle_message(message2)
+
+        # Simulate timeout
+        await asyncio.sleep(self.timeout_s + 0.1)
+        self.mock_callback.assert_called_once_with([message1, message2])
+
+    async def test_no_callback_if_no_messages(self):
+        # Simulate timeout without any messages
+        await asyncio.sleep(self.timeout_s + 0.1)
+        self.mock_callback.assert_not_called()
+
+    async def test_stop_cancels_task_and_clears_messages(self):
+        # Simulate receiving a message
+        message = MagicMock(spec=MqttMessage)
+        await self.collector._handle_message(message)
+
+        # Stop the collector
+        retained_messages = self.collector.stop()
+
+        # Verify the task is canceled
+        self.assertIsNone(self.collector._timeout_task)
+
+        # Verify messages are cleared and returned
+        self.assertEqual(retained_messages, [message])
+        self.assertEqual(len(self.collector.messages), 0)
+
+    async def test_monitor_timeout_handles_cancel(self):
+        # Simulate task cancellation
+        self.collector._start_timeout_task()
+        self.collector._cancel_timeout_task()
+
+        # Verify the task is canceled
+        self.assertIsNone(self.collector._timeout_task)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new `MqttBurstCollector` class to handle MQTT message bursts and includes corresponding unit tests. The changes enhance the MQTT functionality by adding a mechanism to collect and process messages in bursts with a timeout. Below are the most important updates:

### New Feature: `MqttBurstCollector` Class
* Added the `MqttBurstCollector` class in `src/mqtt.py`. This class collects MQTT messages in bursts, triggers a callback after a configurable timeout, and manages message subscriptions and callbacks. It includes methods for starting/stopping the collector, handling incoming messages, and monitoring timeouts.

### Code Enhancements
* Updated imports in `src/mqtt.py` to include `asyncio`, `logging`, and `time`, and added type annotations for `MqttMessage` and other types.

### Unit Tests
* Added a new test suite `test/test_mqtt_burst_collector.py` to validate the functionality of `MqttBurstCollector`. The tests cover message collection, timeout handling, callback triggering, task cancellation, and edge cases like no messages received.

These changes improve the MQTT handling capabilities by providing a structured way to process message bursts and ensure robust behavior through comprehensive testing.